### PR TITLE
Completely non-allocating sampling function for `CirculantEmbedding`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GaussianRandomFields"
 uuid = "e4b2fa32-6e09-5554-b718-106ed5adafe9"
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"

--- a/src/generators/circulant_embedding.jl
+++ b/src/generators/circulant_embedding.jl
@@ -194,17 +194,19 @@ extrapolate(r::AbstractRange{T}, i::Integer) where T =
 randdim(grf::GaussianRandomField{CirculantEmbedding}) = length(grf.data[1])
 
 # sample function
-function _sample(grf::GaussianRandomField{CirculantEmbedding}, xi)
+function _sample(grf::GaussianRandomField{CirculantEmbedding}, xi::AbstractArray{X}) where X
+    v = grf.data[1]
+    w = Array{complex(promote_type(eltype(v), X))}(undef, size(v))
     z = Array{eltype(grf.cov)}(undef, length.(grf.pts))
-    _sample!(z, grf, xi)
+    _sample!(w, z, grf, xi)
 end
 
 # in-place sample function (#22)
-function _sample!(z, grf::GaussianRandomField{CirculantEmbedding}, xi)
+function _sample!(w, z, grf::GaussianRandomField{CirculantEmbedding}, xi)
     v, P = grf.data
 
     # compute multiplication with square root of circulant embedding via FFT
-    w = complex.(v .* reshape(xi, size(v)))
+    w .= complex.(v .* reshape(xi, size(v)))
     mul!(w, P, w)
 
     # extract realization of random field


### PR DESCRIPTION
With this PR, the inner sampling function for CirculantEmbedding is completely non-allocating.  See this benchmark script:
```julia
using GaussianRandomFields, BenchmarkTools

x = 1.:200.
y = 1.:200.
dim = 2
lambda = 1.00
nu = 2.5
sigma = 1.0
cov = CovarianceFunction(dim, Matern(lambda, nu, σ = sigma))
grf = GaussianRandomField(cov, CirculantEmbedding(), x, y, minpadding = 0)
v = grf.data[1]
rnn = randn(size(v))

@info "High-level sampling function"
@btime GaussianRandomFields.sample($grf, xi = $rnn)

w = Matrix{ComplexF64}(undef, size(v))
z = Array{eltype(grf.cov)}(undef, length.(grf.pts))
@info "Inner sampling function"
@btime GaussianRandomFields._sample!($w, $z, $grf, $rnn)
```
Output
```
[ Info: High-level sampling function
  2.584 ms (5 allocations: 4.31 MiB)
[ Info: Inner sampling function
  2.462 ms (0 allocations: 0 bytes)
```
The speedup is modest because the FFT is the bottleneck, but being able to call a function that doesn't allocate allows us to bring allocations down in a computational intensive loop.

Fix #22.

Can we please have a new release after this is merged? :slightly_smiling_face: 