### PR TITLE
Transpose 2D field sample array in plot recipe

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -136,7 +136,16 @@ heatmap
 
 @recipe f(grf::GaussianRandomField{G, C}) where {G, C <: AbstractCovarianceFunction{2}} = begin
     linewidth -> get(plotattributes, :seriestype, :auto) == :contourf ? 0 : :auto
-    grf.pts..., sample(grf)
+    # Plots.[surface|contour|contourf|heatmap] all take a triplet of arguments (x, y, z)
+    # where x is the sequence of coordinates of the spatial grid along the dimension
+    # to be plotted on the horizontal axis, y is the sequence of coordinates of the
+    # spatial grid along the dimension to be plotted on the vertical axis, and z is a
+    # two-dimensional array of shape (length(y), length(x)) with the first dimension
+    # corresponding to vertical plot axis and the second dimension the horizontal plot
+    # axis. As the sample(grf) returns a 2D array with first dimension corresponding
+    # to grf.pts[1] and second dimension corresponding to grf.pts[2] we need to
+    # transpose the sampled array to match with the Plots API
+    grf.pts..., transpose(sample(grf))
 end
 
 # Plot eigenvalues


### PR DESCRIPTION
Fixes #41.

Transposes sampled two-dimensional Gaussian random field arrays in the two-dimensional plot recipe to match with the dimension ordering assumed by the `Plots.jl` API.

After the change in this PR running

```Julia
using GaussianRandomFields, Random, Plots
Random.seed!(87234632804762304832)
cov = CovarianceFunction(2, Matern(1/2, 5/4))
grf = GaussianRandomField(cov, GaussianRandomFields.Cholesky(), range(0, 2, 50), range(0, 1, 25))
grfplots = [plotfunc(grf) for  plotfunc in (surface, contour, contourf, heatmap)]
plot(grfplots...)
```

produces the output

![image](https://user-images.githubusercontent.com/6746980/145557285-754de643-ff7d-446f-80db-d632f21eed85.png)

compared to the output on the current `master` 

![image](https://user-images.githubusercontent.com/6746980/145557506-2d919cf1-2043-490e-ade8-da81a9d32d7f.png)
