### PR TITLE
Allow SpecialFunctions v2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GaussianRandomFields"
 uuid = "e4b2fa32-6e09-5554-b718-106ed5adafe9"
-version = "2.1.5"
+version = "2.1.6"
 
 [deps]
 Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
@@ -16,7 +16,7 @@ Arpack = "0.4, 0.5"
 FFTW = "1.2"
 FastGaussQuadrature = "0.4"
 RecipesBase = "1.0"
-SpecialFunctions = "0.10, 1.0"
+SpecialFunctions = "0.10, 1.0, 2"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
Could you please also tag a new release so that downstream packages can get
latest `SpecialFunctions.jl`?  Thanks!

Side note: note that `CompatHelper` isn't automatically running: https://github.com/PieterjanRobbe/GaussianRandomFields.jl/actions/workflows/CompatHelper.yml