### PR TITLE
Relax compat bounds for FastGaussQuadrature and StatsBase to improve compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,21 +14,22 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-FastGaussQuadrature = "1"
-SpecialFunctions = "2"
-StatsBase = "0.34"
-RecipesBase = "1"
-FFTW = "1"
-Plots = "1"
 Arpack = "0.5"
+FFTW = "1"
+FastGaussQuadrature = "0.3, 0.4, 1"
+Plots = "1"
+RecipesBase = "1"
+SpecialFunctions = "2"
 Statistics = "1"
+StatsBase = "0.33, 0.34"
 julia = "1"
 
 [extras]
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Random", "Test", "Suppressor", "Plots"]
+test = ["Random", "Test", "Suppressor", "UnicodePlots", "Plots"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GaussianRandomFields"
 uuid = "e4b2fa32-6e09-5554-b718-106ed5adafe9"
-version = "2.2.6"
+version = "2.2.7"
 
 [deps]
 Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,16 @@
 ## runtests.jl : run all test files
+# Choose a backend that doesn't pull GR/Qt on Windows CI
+if Sys.iswindows()
+    ENV["PLOTS_DEFAULT_BACKEND"] = "UnicodePlots"
+end
+
 
 using GaussianRandomFields
+
 using Plots
+Sys.iswindows() && unicodeplots()
+@info "Plots backend" backend = string(Plots.backend())
+
 using Random
 using Suppressor
 using Test


### PR DESCRIPTION
This PR updates GaussianRandomFields to version 2.2.7 and relaxes compatibility bounds to enable smoother integration with downstream packages:
- Allows FastGaussQuadrature versions 0.3, 0.4, and 1, improving compatibility with older versions of GaussianProcesses.
- Allows StatsBase versions 0.33 and 0.34, enabling coexistence with packages that have not yet updated to 0.34.

This arose from trying to use the latest version of this package and CalibrateEmulateSample.jl, which are currently incompatible:
```
(compat) pkg> st
Status `~/Downloads/ces_repro_broken/GaussianRandomFields.jl/compat/Project.toml` (empty project)

(compat) pkg> add CalibrateEmulateSample@0.7
   Resolving package versions...
    Updating `~/Downloads/ces_repro_broken/GaussianRandomFields.jl/compat/Project.toml`
  [95e48a1f] + CalibrateEmulateSample v0.7.0
    Updating `~/Downloads/ces_repro_broken/GaussianRandomFields.jl/compat/Manifest.toml`
 ...
(compat) pkg> st
Status `~/Downloads/ces_repro_broken/GaussianRandomFields.jl/compat/Project.toml`
  [95e48a1f] CalibrateEmulateSample v0.7.0

(compat) pkg> add GaussianRandomFields@2.2.6
   Resolving package versions...
ERROR: Unsatisfiable requirements detected for package ScikitLearn [3646fa90]:
 ScikitLearn [3646fa90] log:
 ├─possible versions are: 0.5.0 - 0.7.0 or uninstalled
 ├─restricted by compatibility requirements with CalibrateEmulateSample [95e48a1f] to versions: 0.6.0 - 0.7.0
 │ └─CalibrateEmulateSample [95e48a1f] log:
 │   ├─possible versions are: 0.1.0 - 0.7.0 or uninstalled
 │   └─restricted to versions * by project [850f4d34], leaving only versions: 0.1.0 - 0.7.0
 │     └─project [850f4d34] log:
 │       ├─possible versions are: 0.0.0 or uninstalled
 │       └─project [850f4d34] is fixed to version 0.0.0
 └─restricted by compatibility requirements with StatsBase [2913bbd2] to versions: uninstalled — no versions left
   └─StatsBase [2913bbd2] log:
     ├─possible versions are: 0.24.0 - 0.34.5 or uninstalled
     ├─restricted by compatibility requirements with CalibrateEmulateSample [95e48a1f] to versions: 0.33.0 - 0.34.5
     │ └─CalibrateEmulateSample [95e48a1f] log: see above
     └─restricted by compatibility requirements with GaussianRandomFields [e4b2fa32] to versions: 0.34.0 - 0.34.5
       └─GaussianRandomFields [e4b2fa32] log:
         ├─possible versions are: 1.1.1 - 2.2.6 or uninstalled
         └─restricted to versions 2.2.6 by an explicit requirement, leaving only versions: 2.2.6
```
Widening the compat fixes this issue:
```
(compat) pkg> dev .
   Resolving package versions...
    Updating `~/Downloads/ces_repro_broken/GaussianRandomFields.jl/compat/Project.toml`
  [e4b2fa32] + GaussianRandomFields v2.2.6 `..`
    Updating `~/Downloads/ces_repro_broken/GaussianRandomFields.jl/compat/Manifest.toml`
  [e4b2fa32] ~ GaussianRandomFields v2.1.6 ⇒ v2.2.6 `..`
```